### PR TITLE
Automated Docker Image Publish to Docker Hub and GitHub Packages at Releases

### DIFF
--- a/.github/workflows/docker-image-build-to-test.yml
+++ b/.github/workflows/docker-image-build-to-test.yml
@@ -5,14 +5,15 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_call:
 
 jobs:
-
-  build:
-
+  build-to-test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository 
+      uses: actions/checkout@v4
+      
     - name: Build the Docker image to test
       run: docker build . --file Dockerfile --tag seroba:$(date +%s) --target test

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -5,16 +5,10 @@ on:
     types: [published]
 
 env:
-  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-to-test:
-    uses: ./.github/workflows/docker-image-build-to-test.yml
-
   build-and-push-image:
-    needs: build-to-test
-    
     runs-on: ubuntu-latest
 
     permissions:
@@ -25,10 +19,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -36,9 +36,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
+          images: |
+            ${{ vars.DOCKER_NAMESPACE }}/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -41,6 +41,8 @@ jobs:
           images: |
             ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
             ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -32,6 +32,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -6,9 +6,14 @@ on:
 
 env:
   IMAGE_NAME: ${{ github.repository }}
-
+  
 jobs:
+  build-to-test:
+    uses: ./.github/workflows/docker-image-build-to-test.yml
+
   build-and-push-image:
+    needs: build-to-test
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -9,7 +9,12 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  build-to-test:
+    uses: ./.github/workflows/docker-image-build-to-test.yml
+
   build-and-push-image:
+    needs: build-to-test
+    
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -47,5 +47,6 @@ jobs:
         with:
           context: .
           push: true
+          target: app
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -1,0 +1,42 @@
+name: Docker Image Publish on Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image-publish-on-release.yml
+++ b/.github/workflows/docker-image-publish-on-release.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  IMAGE_NAME: ${{ github.repository }}
-  
 jobs:
   build-to-test:
     uses: ./.github/workflows/docker-image-build-to-test.yml
@@ -42,8 +39,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ vars.DOCKER_NAMESPACE }}/${{ env.IMAGE_NAME }}
-            ghcr.io/${{ env.IMAGE_NAME }}
+            ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
+            ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
This action will run on publish of releases automatically.

It will first run the existing build-to-test action. If successful, it will then build and publish the image to both Docker Hub and GitHub Packages. 

It requies Action Secrets `DOCKER_USERNAME` and `DOCKER_PASSWORD` set up in Settings of the repo. **[We don't have it yet!]**
(`GITHUB_TOKEN` is automatically generated by the action)