### PR TITLE
Upgrade kmc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,10 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install git \
 # Copy repository into the image and install dependencies
 COPY . /seroba/
 RUN cd seroba && \
-  pip3 install pysam==0.15.0 &&\
   /seroba/install_dependencies.sh
 
 # set path
-ENV PATH="/seroba:/seroba/build:/seroba/build/MUMmer3.23:/seroba/build/bowtie2-2.3.1-legacy:/seroba/build/cdhit-4.6.8:${PATH}"
+ENV PATH="/seroba:/seroba/build:/seroba/build/bin:/seroba/build/MUMmer3.23:/seroba/build/bowtie2-2.3.1-legacy:/seroba/build/cdhit-4.6.8:${PATH}"
 
 # install seroba and create database (/seroba/database/)
 RUN cd /seroba && \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -80,7 +80,7 @@ update_path () {
 }
 
 update_path ${build_dir}
-update_path ${build_dir/bin}
+update_path "${build_dir}/bin"
 update_path ${mummer_dir}
 update_path ${bowtie2_dir}
 update_path ${cdhit_dir}

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -4,12 +4,15 @@ set -x
 
 start_dir=$(pwd)
 
-KMC_VERSION=3.2.1
+KMC_VERSION=3.2.2
 MUMMER_VERSION=3.23
 BOWTIE2_VERSION=2.3.1
 CDHIT_VERSION=4.6.8
+PYSAM_VERSION=0.15.0
+PYMUMMER_VERSION=0.10.3
+PYYAML_VERSION=5.4.1
 
-KMC3_DOWNLOAD_URL="https://github.com/refresh-bio/KMC/releases/download/v${KMC_VERSION}/KMC${KMC_VERSION}.linux.tar.gz"
+KMC3_DOWNLOAD_URL="https://github.com/refresh-bio/KMC/releases/download/v${KMC_VERSION}/KMC${KMC_VERSION}.linux.x64.tar.gz"
 MUMMER_DOWNLOAD_URL="http://downloads.sourceforge.net/project/mummer/mummer/${MUMMER_VERSION}/MUMmer${MUMMER_VERSION}.tar.gz"
 BOWTIE2_DOWNLOAD_URL="http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/${BOWTIE2_VERSION}/bowtie2-${BOWTIE2_VERSION}-legacy-linux-x86_64.zip"
 CDHIT_DOWNLOAD_URL="https://github.com/weizhongli/cdhit/archive/V${CDHIT_VERSION}.tar.gz"
@@ -52,12 +55,12 @@ mummer_dir="$build_dir/MUMmer${MUMMER_VERSION}"
 tar -zxf MUMmer${MUMMER_VERSION}.tar.gz
 cd $mummer_dir
 make
+
 # --------------- bowtie2 ------------------
 cd $build_dir
 download $BOWTIE2_DOWNLOAD_URL "bowtie2-${BOWTIE2_VERSION}-legacy.zip"
 bowtie2_dir="$build_dir/bowtie2-${BOWTIE2_VERSION}-legacy"
 unzip -n bowtie2-${BOWTIE2_VERSION}-legacy.zip
-
 
 # --------------- cdhit --------------------
 cd $build_dir
@@ -82,9 +85,7 @@ update_path ${mummer_dir}
 update_path ${bowtie2_dir}
 update_path ${cdhit_dir}
 
-
-pip3 install ariba pysam==0.15.0 pymummer==0.10.3 biopython pyyaml==5.4.1
-
+pip3 install ariba pysam==${PYSAM_VERSION} pymummer==${PYMUMMER_VERSION} biopython pyyaml==${PYYAML_VERSION}
 
 echo "Add the following line to your ~/.bashrc profile"
 echo "export PATH=${build_dir}:${mummer_dir}:${bowtie2_dir}:${cdhit_dir}:${PATH}"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -47,7 +47,7 @@ tar xzf KMC3.linux.tar.gz
 chmod +x bin/kmc
 chmod +x bin/kmc_tools
 chmod +x bin/kmc_dump
-
+kmc_dir="${build_dir}/bin"
 # --------------- mummer ------------------
 cd $build_dir
 download $MUMMER_DOWNLOAD_URL "MUMmer${MUMMER_VERSION}.tar.gz"
@@ -80,7 +80,7 @@ update_path () {
 }
 
 update_path ${build_dir}
-update_path "${build_dir}/bin"
+update_path ${kmc_dir}
 update_path ${mummer_dir}
 update_path ${bowtie2_dir}
 update_path ${cdhit_dir}
@@ -88,4 +88,4 @@ update_path ${cdhit_dir}
 pip3 install ariba pysam==${PYSAM_VERSION} pymummer==${PYMUMMER_VERSION} biopython pyyaml==${PYYAML_VERSION}
 
 echo "Add the following line to your ~/.bashrc profile"
-echo "export PATH=${build_dir}:${mummer_dir}:${bowtie2_dir}:${cdhit_dir}:${PATH}"
+echo "export PATH=${build_dir}:${kmc_dir}:${mummer_dir}:${bowtie2_dir}:${cdhit_dir}:${PATH}"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -4,12 +4,12 @@ set -x
 
 start_dir=$(pwd)
 
-KMC_VERSION=3.0.0
+KMC_VERSION=3.2.1
 MUMMER_VERSION=3.23
 BOWTIE2_VERSION=2.3.1
 CDHIT_VERSION=4.6.8
 
-KMC3_DOWNLOAD_URL="https://github.com/refresh-bio/KMC/releases/download/v${KMC_VERSION}/KMC3.linux.tar.gz"
+KMC3_DOWNLOAD_URL="https://github.com/refresh-bio/KMC/releases/download/v${KMC_VERSION}/KMC${KMC_VERSION}.linux.tar.gz"
 MUMMER_DOWNLOAD_URL="http://downloads.sourceforge.net/project/mummer/mummer/${MUMMER_VERSION}/MUMmer${MUMMER_VERSION}.tar.gz"
 BOWTIE2_DOWNLOAD_URL="http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/${BOWTIE2_VERSION}/bowtie2-${BOWTIE2_VERSION}-legacy-linux-x86_64.zip"
 CDHIT_DOWNLOAD_URL="https://github.com/weizhongli/cdhit/archive/V${CDHIT_VERSION}.tar.gz"
@@ -41,9 +41,9 @@ cd $build_dir
 
 download "${KMC3_DOWNLOAD_URL}" "KMC3.linux.tar.gz"
 tar xzf KMC3.linux.tar.gz
-chmod +x kmc
-chmod +x kmc_tools
-chmod +x kmc_dump
+chmod +x bin/kmc
+chmod +x bin/kmc_tools
+chmod +x bin/kmc_dump
 
 # --------------- mummer ------------------
 cd $build_dir
@@ -77,6 +77,7 @@ update_path () {
 }
 
 update_path ${build_dir}
+update_path ${build_dir/bin}
 update_path ${mummer_dir}
 update_path ${bowtie2_dir}
 update_path ${cdhit_dir}

--- a/seroba/kmc.py
+++ b/seroba/kmc.py
@@ -10,9 +10,9 @@ def run_kmc(sequence_file,kmer_size,temp_dir,prefix):
     file_format = common.detect_sequence_format(sequence_file)
     kmer_count_files = os.path.join(temp_dir,prefix)
     if file_format == 'fa':
-        param = ' -ci1 -m1 -t1 -fm'
+        param = ' -ci1 -m2 -t1 -fm'
     elif file_format =='fq':
-        param = ' -ci4  -m1 -t1'
+        param = ' -ci4  -m2 -t1'
     print(param)
     command1=[ext_progs.exe('kmc') + ' -k'+kmer_size,param,sequence_file,kmer_count_files,temp_dir]
     print(' '.join(command1))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='seroba',
-    version='1.0.4',
+    version='1.0.5',
     description='SEROBA: Serotyping for illumina reads',
     packages = find_packages(),
     author='Lennard Epping',


### PR DESCRIPTION
I've tested this update on the farm using: `/lustre/scratch125/pam/teams/team230/ol6/team284/test_seroba_kmc_upgrade/test_suite.sh`


Results showed no difference in the called serotypes: `/lustre/scratch125/pam/teams/team230/ol6/team284/test_seroba_kmc_upgrade/test_results.csv`

KMC versions:
```
(base) ol6@pathpipe-farm5:/data/pam/team230/ol6/scratch/team284/test_seroba_kmc_upgrade$
singularity exec seroba_test.sif kmc | head -1
K-Mer Counter (KMC) ver. 3.2.2 (2023-03-10)
(base) ol6@pathpipe-farm5:/data/pam/team230/ol6/scratch/team284/test_seroba_kmc_upgrade$
singularity exec seroba_1.0.4.sif kmc | head -1
K-Mer Counter (KMC) ver. 3.0.0 (2017-01-28)
```

The singularity bug fix output is in slack, too long to put here